### PR TITLE
Refactor main function

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,8 +52,6 @@ int cicle(Employee_info e_i)
 
 int main()
 {
-    std::unique_ptr<Employee_info> employeeInfo(new Employee_info);
+    auto employeeInfo = std::make_unique<Employee_info>();
     cicle(*employeeInfo);
-
-    return 0;
 }


### PR DESCRIPTION
Return 0 is not needed in main function.
Use std::make_unique with auto.
Fix a typo in function name cicle() -> cycle().